### PR TITLE
Integrate PostHog feature flag creation with A/B testing plugin

### DIFF
--- a/dev/abTestingPlugin.spec.ts
+++ b/dev/abTestingPlugin.spec.ts
@@ -1,0 +1,527 @@
+import { abTestingPlugin, ABTestingPluginOptions, PostHogConfig, ABCollectionConfig } from '../src/index';
+import type { CollectionConfig, Config } from 'payload/types';
+import { PostHog } from 'posthog-node';
+
+// Mock PostHog client
+jest.mock('posthog-node');
+
+const mockPostHogClientInstance = {
+  getFeatureFlag: jest.fn(),
+  createFeatureFlag: jest.fn(),
+  updateFeatureFlag: jest.fn(),
+  shutdown: jest.fn(),
+};
+
+// @ts-ignore
+PostHog.mockImplementation(() => mockPostHogClientInstance);
+
+describe('abTestingPlugin - PostHog Integration', () => {
+  let mockIncomingConfig: Config;
+  let pluginOptions: ABTestingPluginOptions;
+  const collectionSlug = 'test-collection';
+
+  beforeEach(() => {
+    jest.clearAllMocks(); // Reset all mocks
+
+    pluginOptions = {
+      collections: {
+        [collectionSlug]: { enabled: true }
+      },
+      posthog: {
+        apiKey: 'test_phc_api_key',
+        host: 'https://test.posthog.com',
+      },
+      disabled: false,
+    };
+
+    mockIncomingConfig = {
+      collections: [
+        {
+          slug: collectionSlug,
+          fields: [
+            { name: 'title', type: 'text' },
+            { name: 'content', type: 'richText' },
+          ],
+          hooks: {}, // Ensure hooks object exists
+        } as CollectionConfig,
+      ],
+      hooks: {}, // Ensure global hooks object exists
+    };
+  });
+
+  // Helper function to get the beforeChange hook
+  const getHook = () => {
+    const initializedPlugin = abTestingPlugin(pluginOptions)(mockIncomingConfig);
+    const collectionConfig = initializedPlugin.collections?.find(c => c.slug === collectionSlug);
+    const hook = collectionConfig?.hooks?.beforeChange?.find(h => h.name === 'copyToVariantHook');
+    if (!hook) throw new Error('copyToVariantHook not found');
+    return hook;
+  };
+
+  it('should create a new feature flag when A/B testing is enabled for the first time (auto-generated key)', async () => {
+    const hook = getHook();
+    const mockData = {
+      title: 'Test Document',
+      enableABTesting: true,
+      posthogVariantName: 'variant-name',
+      abVariant: {}, // Ensure abVariant is an object
+    };
+    const mockOriginalDoc = {
+      title: 'Test Document',
+      enableABTesting: false,
+    };
+
+    mockPostHogClientInstance.getFeatureFlag.mockRejectedValueOnce({ statusCode: 404 }); // Simulate flag not found
+    mockPostHogClientInstance.createFeatureFlag.mockResolvedValueOnce({ id: 'flag_id_123', key: 'generated_key' });
+
+    const result = await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    expect(PostHog).toHaveBeenCalledWith(pluginOptions.posthog?.apiKey, { host: pluginOptions.posthog?.host });
+    expect(mockPostHogClientInstance.getFeatureFlag).toHaveBeenCalledWith(expect.stringContaining(`posthog_ab_${collectionSlug}_`));
+
+    const generatedKey = mockPostHogClientInstance.getFeatureFlag.mock.calls[0][0];
+    expect(mockPostHogClientInstance.createFeatureFlag).toHaveBeenCalledWith({
+      key: generatedKey,
+      name: `A/B Test: ${collectionSlug} - Test Document`,
+      active: true,
+      filters: {
+        groups: [{ properties: [], rollout_percentage: null }],
+        multivariate: {
+          variants: [
+            { key: 'control', name: 'Control', rollout_percentage: 50 },
+            { key: 'variant-name', name: 'Variant Name', rollout_percentage: 50 },
+          ],
+        },
+      },
+      ensure_persistence: true,
+    });
+    expect(result.posthogFeatureFlagKey).toBe(generatedKey);
+    expect(mockPostHogClientInstance.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('should create a new feature flag using provided posthogFeatureFlagKey', async () => {
+    const hook = getHook();
+    const providedKey = 'my_custom_flag_key';
+    const mockData = {
+      title: 'Test Doc with Key',
+      enableABTesting: true,
+      posthogFeatureFlagKey: providedKey,
+      posthogVariantName: 'custom-variant',
+      abVariant: {},
+    };
+    const mockOriginalDoc = {
+      enableABTesting: false,
+    };
+
+    mockPostHogClientInstance.getFeatureFlag.mockRejectedValueOnce({ statusCode: 404 });
+    mockPostHogClientInstance.createFeatureFlag.mockResolvedValueOnce({ id: 'flag_id_456', key: providedKey });
+
+    await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    expect(mockPostHogClientInstance.getFeatureFlag).toHaveBeenCalledWith(providedKey);
+    expect(mockPostHogClientInstance.createFeatureFlag).toHaveBeenCalledWith(expect.objectContaining({
+      key: providedKey,
+      name: `A/B Test: ${collectionSlug} - Test Doc with Key`,
+      filters: expect.objectContaining({
+        multivariate: expect.objectContaining({
+          variants: expect.arrayContaining([
+            expect.objectContaining({ key: 'custom-variant' })
+          ])
+        })
+      })
+    }));
+    expect(mockPostHogClientInstance.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('should update an existing feature flag if getFeatureFlag returns a flag', async () => {
+    const hook = getHook();
+    const existingKey = 'existing_flag_key';
+    const mockData = {
+      title: 'Updated Title',
+      enableABTesting: true,
+      posthogFeatureFlagKey: existingKey,
+      posthogVariantName: 'updated-variant',
+      abVariant: {},
+    };
+    const mockOriginalDoc = {
+      title: 'Old Title',
+      enableABTesting: true, // A/B testing was already enabled
+      posthogFeatureFlagKey: existingKey,
+    };
+    const existingFlag = { id: 'flag_id_789', key: existingKey, name: 'Old Name', active: true };
+
+    mockPostHogClientInstance.getFeatureFlag.mockResolvedValueOnce(existingFlag);
+    mockPostHogClientInstance.updateFeatureFlag.mockResolvedValueOnce({ ...existingFlag, name: `A/B Test: ${collectionSlug} - Updated Title` });
+
+    await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    expect(mockPostHogClientInstance.getFeatureFlag).toHaveBeenCalledWith(existingKey);
+    expect(mockPostHogClientInstance.updateFeatureFlag).toHaveBeenCalledWith(existingFlag.id, {
+      name: `A/B Test: ${collectionSlug} - Updated Title`,
+      filters: {
+        groups: [{ properties: [], rollout_percentage: null }],
+        multivariate: {
+          variants: [
+            { key: 'control', name: 'Control', rollout_percentage: 50 },
+            { key: 'updated-variant', name: 'Updated Variant', rollout_percentage: 50 },
+          ],
+        },
+      },
+      active: true,
+    });
+    expect(mockPostHogClientInstance.createFeatureFlag).not.toHaveBeenCalled();
+    expect(mockPostHogClientInstance.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('should deactivate an existing feature flag when A/B testing is disabled', async () => {
+    const hook = getHook();
+    const flagKey = 'flag_to_deactivate';
+    const mockData = {
+      enableABTesting: false, // Disabling A/B testing
+      posthogFeatureFlagKey: flagKey,
+      abVariant: {},
+    };
+    const mockOriginalDoc = {
+      enableABTesting: true, // Was enabled
+      posthogFeatureFlagKey: flagKey,
+    };
+    const existingFlag = { id: 'flag_id_abc', key: flagKey, name: 'Test Flag', active: true };
+
+    mockPostHogClientInstance.getFeatureFlag.mockResolvedValueOnce(existingFlag);
+    mockPostHogClientInstance.updateFeatureFlag.mockResolvedValueOnce({ ...existingFlag, active: false });
+
+    await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    expect(mockPostHogClientInstance.getFeatureFlag).toHaveBeenCalledWith(flagKey);
+    expect(mockPostHogClientInstance.updateFeatureFlag).toHaveBeenCalledWith(existingFlag.id, {
+      active: false,
+    });
+    expect(mockPostHogClientInstance.createFeatureFlag).not.toHaveBeenCalled();
+    expect(mockPostHogClientInstance.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call PostHog methods if apiKey is not provided', async () => {
+    pluginOptions.posthog!.apiKey = undefined; // No API key
+    const hook = getHook();
+    const mockData = { enableABTesting: true, abVariant: {} };
+    const mockOriginalDoc = { enableABTesting: false };
+
+    console.warn = jest.fn(); // Spy on console.warn
+
+    await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    expect(PostHog).not.toHaveBeenCalled();
+    expect(mockPostHogClientInstance.createFeatureFlag).not.toHaveBeenCalled();
+    expect(mockPostHogClientInstance.updateFeatureFlag).not.toHaveBeenCalled();
+    expect(mockPostHogClientInstance.shutdown).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('PostHog API key not configured'));
+  });
+
+  it('should handle errors from createFeatureFlag and still complete', async () => {
+    const hook = getHook();
+    const mockData = { enableABTesting: true, abVariant: {} };
+    const mockOriginalDoc = { enableABTesting: false };
+
+    mockPostHogClientInstance.getFeatureFlag.mockRejectedValueOnce({ statusCode: 404 });
+    mockPostHogClientInstance.createFeatureFlag.mockRejectedValueOnce(new Error('PostHog API Error'));
+    console.error = jest.fn(); // Spy on console.error
+
+    const result = await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    expect(mockPostHogClientInstance.createFeatureFlag).toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Error creating/updating PostHog feature flag'), expect.any(Error));
+    expect(result).toEqual(mockData); // Hook should still return data
+    expect(mockPostHogClientInstance.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle errors from updateFeatureFlag (when activating) and still complete', async () => {
+    const hook = getHook();
+    const existingKey = 'existing_flag_key_error';
+    const mockData = {
+      enableABTesting: true,
+      posthogFeatureFlagKey: existingKey,
+      abVariant: {},
+    };
+    const mockOriginalDoc = { enableABTesting: true, posthogFeatureFlagKey: existingKey };
+    const existingFlag = { id: 'flag_id_err_update', key: existingKey, name: 'Error Flag', active: true };
+
+    mockPostHogClientInstance.getFeatureFlag.mockResolvedValueOnce(existingFlag);
+    mockPostHogClientInstance.updateFeatureFlag.mockRejectedValueOnce(new Error('PostHog API Update Error'));
+    console.error = jest.fn();
+
+    const result = await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    expect(mockPostHogClientInstance.updateFeatureFlag).toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Error creating/updating PostHog feature flag'), expect.any(Error));
+    expect(result).toEqual(mockData);
+    expect(mockPostHogClientInstance.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle errors from updateFeatureFlag (when deactivating) and still complete', async () => {
+    const hook = getHook();
+    const flagKey = 'flag_to_deactivate_error';
+    const mockData = { enableABTesting: false, posthogFeatureFlagKey: flagKey, abVariant: {} };
+    const mockOriginalDoc = { enableABTesting: true, posthogFeatureFlagKey: flagKey };
+    const existingFlag = { id: 'flag_id_err_deactivate', key: flagKey, name: 'Error Deactivate Flag', active: true };
+
+    mockPostHogClientInstance.getFeatureFlag.mockResolvedValueOnce(existingFlag);
+    mockPostHogClientInstance.updateFeatureFlag.mockRejectedValueOnce(new Error('PostHog API Deactivation Error'));
+    console.error = jest.fn();
+
+    const result = await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    expect(mockPostHogClientInstance.updateFeatureFlag).toHaveBeenCalledWith(existingFlag.id, { active: false });
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Error deactivating PostHog feature flag'), expect.any(Error));
+    expect(result).toEqual(mockData);
+    expect(mockPostHogClientInstance.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('should still call shutdown if getFeatureFlag throws an error (not 404) when creating/updating', async () => {
+    const hook = getHook();
+    const mockData = { enableABTesting: true, abVariant: {} };
+    const mockOriginalDoc = { enableABTesting: false };
+
+    mockPostHogClientInstance.getFeatureFlag.mockRejectedValueOnce(new Error('Network Error'));
+    console.error = jest.fn();
+
+    await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    expect(mockPostHogClientInstance.getFeatureFlag).toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Error creating/updating PostHog feature flag'), expect.any(Error));
+    expect(mockPostHogClientInstance.createFeatureFlag).not.toHaveBeenCalled();
+    expect(mockPostHogClientInstance.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('should still call shutdown if getFeatureFlag throws an error when deactivating', async () => {
+    const hook = getHook();
+    const flagKey = 'flag_get_error_deactivate';
+    const mockData = { enableABTesting: false, posthogFeatureFlagKey: flagKey, abVariant: {} };
+    const mockOriginalDoc = { enableABTesting: true, posthogFeatureFlagKey: flagKey };
+
+    mockPostHogClientInstance.getFeatureFlag.mockRejectedValueOnce(new Error('Network Error on Get for Deactivation'));
+    console.error = jest.fn();
+
+    await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    expect(mockPostHogClientInstance.getFeatureFlag).toHaveBeenCalledWith(flagKey);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Error deactivating PostHog feature flag'), expect.any(Error));
+    expect(mockPostHogClientInstance.updateFeatureFlag).not.toHaveBeenCalled();
+    expect(mockPostHogClientInstance.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('should use default "variant" for posthogVariantName if not provided', async () => {
+    const hook = getHook();
+    const mockData = {
+      title: 'Test Document Default Variant',
+      enableABTesting: true,
+      // posthogVariantName is missing
+      abVariant: {},
+    };
+    const mockOriginalDoc = { enableABTesting: false };
+
+    mockPostHogClientInstance.getFeatureFlag.mockRejectedValueOnce({ statusCode: 404 });
+    mockPostHogClientInstance.createFeatureFlag.mockResolvedValueOnce({ id: 'flag_id_default', key: 'generated_key_default' });
+
+    await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    const generatedKey = mockPostHogClientInstance.getFeatureFlag.mock.calls[0][0];
+    expect(mockPostHogClientInstance.createFeatureFlag).toHaveBeenCalledWith(expect.objectContaining({
+      key: generatedKey,
+      filters: expect.objectContaining({
+        multivariate: expect.objectContaining({
+          variants: expect.arrayContaining([
+            expect.objectContaining({ key: 'variant', name: 'Variant' }) // Default name
+          ])
+        })
+      })
+    }));
+  });
+
+  it('should use default "variant" for posthogVariantName during update if not provided', async () => {
+    const hook = getHook();
+    const existingKey = 'existing_flag_key_default_variant';
+    const mockData = {
+      title: 'Updated Title Default Variant',
+      enableABTesting: true,
+      posthogFeatureFlagKey: existingKey,
+      // posthogVariantName is missing
+      abVariant: {},
+    };
+    const mockOriginalDoc = { enableABTesting: true, posthogFeatureFlagKey: existingKey };
+    const existingFlag = { id: 'flag_id_default_update', key: existingKey, name: 'Old Name', active: true };
+
+    mockPostHogClientInstance.getFeatureFlag.mockResolvedValueOnce(existingFlag);
+    mockPostHogClientInstance.updateFeatureFlag.mockResolvedValueOnce({ ...existingFlag, name: `A/B Test: ${collectionSlug} - Updated Title Default Variant` });
+
+    await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    expect(mockPostHogClientInstance.updateFeatureFlag).toHaveBeenCalledWith(existingFlag.id, expect.objectContaining({
+      filters: expect.objectContaining({
+        multivariate: expect.objectContaining({
+          variants: expect.arrayContaining([
+            expect.objectContaining({ key: 'variant', name: 'Variant' }) // Default name
+          ])
+        })
+      })
+    }));
+  });
+
+  it('should correctly generate feature flag name using originalDoc.title if data.title is not available', async () => {
+    const hook = getHook();
+    const mockData = { // title is missing
+      enableABTesting: true,
+      abVariant: {},
+    };
+    const mockOriginalDoc = {
+      title: 'Original Document Title', // Title from originalDoc
+      enableABTesting: false,
+    };
+
+    mockPostHogClientInstance.getFeatureFlag.mockRejectedValueOnce({ statusCode: 404 });
+    mockPostHogClientInstance.createFeatureFlag.mockResolvedValueOnce({ id: 'flag_id_orig_title', key: 'generated_key_orig_title' });
+
+    await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    const generatedKey = mockPostHogClientInstance.getFeatureFlag.mock.calls[0][0];
+    expect(mockPostHogClientInstance.createFeatureFlag).toHaveBeenCalledWith(expect.objectContaining({
+      key: generatedKey,
+      name: `A/B Test: ${collectionSlug} - Original Document Title`, // Name uses originalDoc.title
+    }));
+  });
+
+  it('should correctly generate feature flag name using flag key if neither data.title nor originalDoc.title is available', async () => {
+    const hook = getHook();
+    const mockData = { // title is missing
+      enableABTesting: true,
+      abVariant: {},
+    };
+    const mockOriginalDoc = { // title is also missing
+      enableABTesting: false,
+    };
+    const generatedKeyFallback = `posthog_ab_${collectionSlug}_${Date.now()}`; // Approximate key
+
+    mockPostHogClientInstance.getFeatureFlag.mockImplementationOnce(key => {
+      // Simulate a key that would be generated if Date.now() was used
+      // This is a bit tricky to match perfectly, so we check it contains the base part
+      expect(key).toContain(`posthog_ab_${collectionSlug}_`);
+      return Promise.reject({ statusCode: 404 });
+    });
+    mockPostHogClientInstance.createFeatureFlag.mockImplementationOnce(params => {
+      expect(params.name).toBe(`A/B Test: ${collectionSlug} - ${params.key}`); // Name uses the generated key
+      return Promise.resolve({ id: 'flag_id_key_title', key: params.key });
+    });
+
+    await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    expect(mockPostHogClientInstance.createFeatureFlag).toHaveBeenCalled();
+  });
+
+
+  // Test for content copying logic (ensure it's not broken by PostHog changes)
+  // This is a simplified version, more detailed tests for sanitizeObject etc. would be separate
+  it('should still copy content to variant when A/B testing is enabled for the first time', async () => {
+    // Modify pluginOptions to include specific fields for this collection
+    pluginOptions.collections = {
+      [collectionSlug]: {
+        enabled: true,
+        fields: ['title', 'content'], // Explicitly define fields to copy
+      }
+    };
+    const hook = getHook();
+
+    const mockData = {
+      title: 'New Title from Data', // This should be copied
+      content: [{ type: 'paragraph', children: [{ text: 'New content from Data' }] }], // This should be copied
+      enableABTesting: true,
+      abVariant: {},
+    };
+    const mockOriginalDoc = {
+      title: 'Old Title from OriginalDoc',
+      content: [{ type: 'paragraph', children: [{ text: 'Old content from OriginalDoc' }] }],
+      enableABTesting: false,
+    };
+
+    mockPostHogClientInstance.getFeatureFlag.mockRejectedValueOnce({ statusCode: 404 });
+    mockPostHogClientInstance.createFeatureFlag.mockResolvedValueOnce({ id: 'flag_id_content_copy', key: 'key_content_copy' });
+
+    const result = await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    expect(result.abVariant.title).toBe('New Title from Data');
+    expect(result.abVariant.content).toEqual([{ type: 'paragraph', children: [{ text: 'New content from Data' }] }]);
+    expect(mockPostHogClientInstance.createFeatureFlag).toHaveBeenCalled(); // Ensure PostHog logic still runs
+    expect(mockPostHogClientInstance.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('should clear abVariant if A/B testing is disabled and no PostHog key to deactivate', async () => {
+    const hook = getHook();
+    const mockData = {
+      enableABTesting: false, // Disabling A/B testing
+      abVariant: { title: 'some variant data' },
+      // No posthogFeatureFlagKey
+    };
+    const mockOriginalDoc = {
+      enableABTesting: true, // Was enabled
+      abVariant: { title: 'some variant data' },
+    };
+
+    console.warn = jest.fn();
+
+    const result = await hook({ data: mockData, originalDoc: mockOriginalDoc, collection: { slug: collectionSlug } });
+
+    expect(result.abVariant).toEqual({});
+    expect(mockPostHogClientInstance.getFeatureFlag).not.toHaveBeenCalled();
+    expect(mockPostHogClientInstance.updateFeatureFlag).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('PostHog API key or feature flag key missing. Skipping feature flag deactivation.'));
+    expect(mockPostHogClientInstance.shutdown).not.toHaveBeenCalled(); // No client initialized
+  });
+});
+
+// Minimal SanitizeObject test (ideally in its own file if complex)
+// For now, just ensuring it's callable as it's used by the hook
+// The plugin itself defines sanitizeObject, this is more of an integration check
+describe('abTestingPlugin - sanitizeObject (basic check)', () => {
+   let mockIncomingConfig: Config;
+   let pluginOptions: ABTestingPluginOptions;
+   const collectionSlug = 'sanitize-test-collection';
+
+  beforeEach(() => {
+    pluginOptions = {
+      collections: { [collectionSlug]: { enabled: true, fields: ['complexField'] } },
+      disabled: false,
+    };
+    mockIncomingConfig = {
+      collections: [{
+        slug: collectionSlug,
+        fields: [{ name: 'complexField', type: 'group', fields: [{name: 'text', type: 'text'}] }],
+        hooks: {},
+      } as CollectionConfig],
+    };
+  });
+
+  it('sanitizeObject should be callable and remove system fields', () => {
+    const initializedPlugin = abTestingPlugin(pluginOptions)(mockIncomingConfig);
+    const collectionConfig = initializedPlugin.collections?.find(c => c.slug === collectionSlug);
+    const hook = collectionConfig?.hooks?.beforeChange?.find(h => h.name === 'copyToVariantHook');
+    if (!hook) throw new Error('copyToVariantHook not found for sanitize test');
+
+    // This is an indirect test. The hook uses sanitizeObject internally.
+    // We are checking if the hook runs without error when processing a complex field.
+    const dataWithId = {
+      complexField: { id: '123', _id: '456', name: 'test', __v: 1, createdAt: 'date', updatedAt: 'date' },
+      enableABTesting: true,
+    };
+    const originalDoc = { enableABTesting: false };
+
+    mockPostHogClientInstance.getFeatureFlag.mockRejectedValueOnce({ statusCode: 404 });
+    mockPostHogClientInstance.createFeatureFlag.mockResolvedValueOnce({ id: 'flag_id_sanitize', key: 'key_sanitize' });
+
+    // @ts-ignore
+    return hook({ data: dataWithId, originalDoc, collection: { slug: collectionSlug } }).then(result => {
+      expect(result.abVariant.complexField).toBeDefined();
+      expect(result.abVariant.complexField.id).toBeUndefined();
+      expect(result.abVariant.complexField._id).toBeUndefined();
+      expect(result.abVariant.complexField.__v).toBeUndefined();
+      expect(result.abVariant.complexField.name).toBe('test');
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   },
   "registry": "https://registry.npmjs.org/",
   "dependencies": {
-    "lodash.merge": "^4.6.2"
+    "lodash.merge": "^4.6.2",
+    "posthog-node": "^4.17.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       lodash.merge:
         specifier: ^4.6.2
         version: 4.6.2
+      posthog-node:
+        specifier: ^4.17.1
+        version: 4.17.1
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.1
@@ -2177,6 +2180,9 @@ packages:
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -2188,6 +2194,9 @@ packages:
   axe-core@4.10.3:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
+
+  axios@1.9.0:
+    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2448,6 +2457,10 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -2621,6 +2634,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -3265,6 +3282,10 @@ packages:
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
+
+  form-data@4.0.2:
+    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+    engines: {node: '>= 6'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -3954,7 +3975,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lines-and-columns@1.2.4:
@@ -4110,8 +4130,16 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mimic-fn@2.1.0:
@@ -4575,6 +4603,10 @@ packages:
   postgres-range@1.1.4:
     resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
+  posthog-node@4.17.1:
+    resolution: {integrity: sha512-cVlQPOwOPjakUnrueKRCQe1m2Ku+XzKaOos7Tn/zDZkkZFeBT/byP7tbNf7LiwhaBRWFBRowZZb/MsTtSRaorg==}
+    engines: {node: '>=15.0.0'}
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
@@ -4612,6 +4644,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
@@ -7918,6 +7953,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  asynckit@0.4.0: {}
+
   atomic-sleep@1.0.0: {}
 
   available-typed-arrays@1.0.7:
@@ -7925,6 +7962,14 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.10.3: {}
+
+  axios@1.9.0:
+    dependencies:
+      follow-redirects: 1.15.9(debug@4.4.1)
+      form-data: 4.0.2
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   axobject-query@4.1.0: {}
 
@@ -8206,6 +8251,10 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@2.20.3: {}
 
   commander@6.2.1: {}
@@ -8363,6 +8412,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -8638,7 +8689,7 @@ snapshots:
       eslint: 9.27.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.4.2(eslint@9.27.0)(typescript@5.7.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0)(typescript@5.7.3))(eslint@9.27.0))(eslint@9.27.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0)(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.27.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0)(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.4.2(eslint@9.27.0)(typescript@5.7.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0)(typescript@5.7.3))(eslint@9.27.0))(eslint@9.27.0))(eslint@9.27.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.27.0)
       eslint-plugin-react: 7.37.5(eslint@9.27.0)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.27.0)
@@ -8672,7 +8723,7 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.7.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0)(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.27.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0)(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.4.2(eslint@9.27.0)(typescript@5.7.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0)(typescript@5.7.3))(eslint@9.27.0))(eslint@9.27.0))(eslint@9.27.0)
       eslint-plugin-import-x: 4.4.2(eslint@9.27.0)(typescript@5.7.3)
     transitivePeerDependencies:
       - supports-color
@@ -8723,7 +8774,7 @@ snapshots:
       - typescript
     optional: true
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0)(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.27.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0)(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.4.2(eslint@9.27.0)(typescript@5.7.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0)(typescript@5.7.3))(eslint@9.27.0))(eslint@9.27.0))(eslint@9.27.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -9246,6 +9297,13 @@ snapshots:
       is-callable: 1.2.7
 
   form-data-encoder@2.1.4: {}
+
+  form-data@4.0.2:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      mime-types: 2.1.35
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -10391,7 +10449,13 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mimic-fn@2.1.0: {}
 
@@ -10895,6 +10959,12 @@ snapshots:
 
   postgres-range@1.1.4: {}
 
+  posthog-node@4.17.1:
+    dependencies:
+      axios: 1.9.0
+    transitivePeerDependencies:
+      - debug
+
   prebuild-install@7.1.3:
     dependencies:
       detect-libc: 2.0.4
@@ -10938,6 +11008,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proxy-from-env@1.1.0: {}
 
   pump@3.0.2:
     dependencies:


### PR DESCRIPTION
This change enhances the A/B testing plugin to automatically create and manage feature flags in PostHog when you enable or disable A/B testing for a document.

Key features:
- When you enable A/B testing on a document, a corresponding feature flag is created in PostHog.
- If you provide a `posthogFeatureFlagKey`, it's used; otherwise, a key is automatically generated.
- The feature flag in PostHog is configured as a multivariate flag with 'control' and 'variant' groups, each initially set to 50% rollout.
- When you disable A/B testing, the corresponding PostHog feature flag is deactivated.
- You can configure the PostHog API key and host via the plugin options.
- Errors during PostHog API interaction are logged and do not disrupt the main Payload CMS operations.
- Includes comprehensive unit tests mocking the PostHog client to verify all aspects of the integration, including creation, update, deactivation, error handling, and API key management.