### PR TITLE
Update event option values to use underscores

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -290,15 +290,15 @@ export const abTestingPlugin =
                 options: [
                   {
                     label: 'CTA Click',
-                    value: 'cta-click',
+                    value: 'cta_click',
                   },
                   {
                     label: 'Form Submit',
-                    value: 'form-submit',
+                    value: 'form_submit',
                   },
                   {
                     label: 'Page View',
-                    value: 'page-view',
+                    value: 'page_view',
                   },
                 ],
               },


### PR DESCRIPTION
Changed event option values from kebab-case to snake_case for consistency. This affects 'CTA Click', 'Form Submit', and 'Page View' options in the AB testing plugin.